### PR TITLE
Allow substitution solving to be done on parallel goroutines

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ Commands:
 Given a dictionary file, attempt to find a set of cribs that matches the ciphertext.
 
     ./puzzle_helper cryptogram substitution solve string1 [string2...] --dictionary path_to_dictionary_file
+
+The `solve` command will attempt to solve the set of strings concurrently. You can configure the number of goroutines that will get made for parallel solving with the --concurrency argument (default is 10):
+
+    ./puzzle_helper cryptogram substitution solve string1 [string2...] --dictionary path_to_dictionary_file -concurrency 2

--- a/cmd/cryptogram.go
+++ b/cmd/cryptogram.go
@@ -24,6 +24,7 @@ import (
 
 // cryptogramCmd represents the cryptogram command
 var dictionaryFile string
+var concurrency int
 
 var cryptogramCmd = &cobra.Command{
 	Use:   "cryptogram",
@@ -69,6 +70,7 @@ func init() {
 	substitutionCmd.AddCommand(substitutionReplCmd)
 	substitutionSolveCmd.Flags().StringVarP(&dictionaryFile, "dictionary", "d", "", "Dictionary file to use, or - to use stdin")
 	substitutionSolveCmd.MarkFlagRequired("dictionary")
+	substitutionSolveCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 10, "The maximum goroutines to create for solving. Defaults to 10.")
 	substitutionCmd.AddCommand(substitutionSolveCmd)
 
 	cryptogramCmd.AddCommand(freqCmd)

--- a/cmd/substitution_test.go
+++ b/cmd/substitution_test.go
@@ -39,6 +39,53 @@ func TestFindMatchesFromDictionary(test *testing.T) {
 	}
 }
 
+type partitionTest struct {
+	count                 int
+	expectedMatchesAtZero []string
+}
+
+func stringInSlice(seek string, stringSlice []string) bool {
+	for _, curString := range stringSlice {
+		if seek == curString {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPartitionMatches(test *testing.T) {
+	data := &substitutionWordMatches{"HELLO", "ABCCD", []string{"YUCCA", "WATTS", "VROOM", "VILLA", "SWEET"}}
+
+	tests := []partitionTest{
+		partitionTest{5, []string{"YUCCA"}},
+		partitionTest{1, []string{"YUCCA", "WATTS", "VROOM", "VILLA", "SWEET"}},
+		partitionTest{2, []string{"YUCCA", "VROOM", "SWEET"}},
+	}
+
+	for index, curTest := range tests {
+		partitioned := partitionMatches(curTest.count, data)
+
+		if len(partitioned) != curTest.count {
+			test.Errorf("Test case %v: expected %v partitions but got %v", index, curTest.count, len(partitioned))
+		}
+
+		// verify matches are what's expected
+		if len(partitioned[0].patternMatches) != len(curTest.expectedMatchesAtZero) {
+			test.Errorf("Test case %d: Expected partition 0 to have %d items but had %d",
+				index, len(curTest.expectedMatchesAtZero), len(partitioned[0].patternMatches))
+		}
+
+		for _, expectToFind := range curTest.expectedMatchesAtZero {
+			if !stringInSlice(expectToFind, partitioned[0].patternMatches) {
+				test.Errorf("Test case %d: Expected to find %s in %v but did not",
+					index, expectToFind, partitioned[0].patternMatches)
+			}
+		}
+
+	}
+
+}
+
 func TestCopyByteMap(test *testing.T) {
 	source := map[byte]byte{
 		'A': 'B',


### PR DESCRIPTION
You can control the level of concurrency by passing the --concurrency flag (defaults to 10)